### PR TITLE
Изменение ссылок на корневые сертификаты

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -38,4 +38,4 @@ RUN cd /opt/ncanode && mkdir -p ca/trusted && cd ca/trusted && wget \
     https://pki.gov.kz/cert/nca_rsa.crt \
     https://pki.gov.kz/cert/nca_gost.crt
 COPY --from=0 /usr/local/src/NCANode/NCANode.ini ./NCANode.ini
-COPY --from=0 /usr/local/src/NCANode/target/ncanode-*-jar-with-dependencies.jar ./ncanode.jar
+COPY --from=0 /usr/local/src/NCANode/target/ncanode-jar-with-dependencies.jar ./ncanode.jar

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -29,13 +29,13 @@ RUN mkdir logs \
  && ln -s /dev/stderr logs/error.log \
  && mkdir -p ca/root \
  && cd ca/root && wget \
-    http://www.pki.gov.kz/cert/root_rsa.crt \
-    http://www.pki.gov.kz/cert/root_gost.crt
+    https://pki.gov.kz/cert/root_rsa.crt \
+    https://pki.gov.kz/cert/root_gost.crt
 
 RUN cd /opt/ncanode && mkdir -p ca/trusted && cd ca/trusted && wget \
-    http://www.pki.gov.kz/cert/pki_rsa.crt \
-    http://www.pki.gov.kz/cert/pki_gost.crt \
-    http://www.pki.gov.kz/cert/nca_rsa.crt \
-    http://www.pki.gov.kz/cert/nca_gost.crt
+    https://pki.gov.kz/cert/pki_rsa.crt \
+    https://pki.gov.kz/cert/pki_gost.crt \
+    https://pki.gov.kz/cert/nca_rsa.crt \
+    https://pki.gov.kz/cert/nca_gost.crt
 COPY --from=0 /usr/local/src/NCANode/NCANode.ini ./NCANode.ini
 COPY --from=0 /usr/local/src/NCANode/target/ncanode-*-jar-with-dependencies.jar ./ncanode.jar

--- a/build_release.sh
+++ b/build_release.sh
@@ -34,12 +34,12 @@ mkdir -p "$RELEASE_DIR/cache/crl" && \
 mkdir "$RELEASE_DIR/logs" && \
 touch "$RELEASE_DIR/logs/error.log" && \
 touch "$RELEASE_DIR/logs/request.log" && \
-curl -k -L -o "$RELEASE_DIR/ca/root/root_rsa.crt" http://www.pki.gov.kz/cert/root_rsa.crt && \
-curl -k -L -o "$RELEASE_DIR/ca/root/root_gost.crt" http://www.pki.gov.kz/cert/root_gost.crt && \
-curl -k -L -o "$RELEASE_DIR/ca/trusted/pki_rsa.crt" http://www.pki.gov.kz/cert/pki_rsa.crt && \
-curl -k -L -o "$RELEASE_DIR/ca/trusted/pki_gost.crt" http://www.pki.gov.kz/cert/pki_gost.crt && \
-curl -k -L -o "$RELEASE_DIR/ca/trusted/nca_rsa.crt" http://www.pki.gov.kz/cert/nca_rsa.crt && \
-curl -k -L -o "$RELEASE_DIR/ca/trusted/nca_gost.crt" http://www.pki.gov.kz/cert/nca_gost.crt && \
+curl -k -L -o "$RELEASE_DIR/ca/root/root_rsa.crt" https://pki.gov.kz/cert/root_rsa.crt && \
+curl -k -L -o "$RELEASE_DIR/ca/root/root_gost.crt" https://pki.gov.kz/cert/root_gost.crt && \
+curl -k -L -o "$RELEASE_DIR/ca/trusted/pki_rsa.crt" https://pki.gov.kz/cert/pki_rsa.crt && \
+curl -k -L -o "$RELEASE_DIR/ca/trusted/pki_gost.crt" https://pki.gov.kz/cert/pki_gost.crt && \
+curl -k -L -o "$RELEASE_DIR/ca/trusted/nca_rsa.crt" https://pki.gov.kz/cert/nca_rsa.crt && \
+curl -k -L -o "$RELEASE_DIR/ca/trusted/nca_gost.crt" https://pki.gov.kz/cert/nca_gost.crt && \
 cd "$RELEASE_DIR" && \
 zip "../NCANode.zip" -r . && \
 tar cvzf "../NCANode.tar.gz" . && \


### PR DESCRIPTION
Ссылки на корневые сертификаты http://www.pki.gov.kz/... теперь не доступны. Они перешли на схему https без субдомена www.

Также последняя команда в Docker.build падала с ошибкой из-за неверного пути к файлу.