### PR TITLE
Метод подписи xml запросов в формате, требуемом в smartbridge

### DIFF
--- a/NCANode.postman_collection.json
+++ b/NCANode.postman_collection.json
@@ -66,6 +66,36 @@
 			"response": []
 		},
 		{
+			"name": "XML.signWithSecurityHeader",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"version\": \"1.0\",\n\t\"method\": \"XML.signWithSecurityHeader\",\n\t\"params\": {\n\t\t\"p12\":\"MIINkwIBAzCCDU0GCSqGSIb3DQEHAaCCDT4Egg06MIAwgAYJKoZIhvcNAQcBoIAEggWcMIIFmDCCBZQGCyqGSIb3DQEMCgECoIIE+jCCBPYwKAYKKoZIhvcNAQwBAzAaBBQzwa8hA6IVQ8Dkz2V+mhYE/UCE7gICBAAEggTI5tLwNi/DoOWJ7D1S9vKrozFgsHxv/Yjw9jS5C1JNN55xtazMJ3i8pKvvVbY7WqLwXpsJWaS6297OKPkUW5uc9jNLDS8cc37PgaxhA05gKyO97RdGlglnEqxJsy7qsQIEIT66FYOoNnmxpV2Tw3bjEm2xlNLLbbbETnjCyF+M7MFm8g6wA61hisDy1areY3ypTA4Qn5eMoKSvhxlYC+FEAgtLMizwBetfOgkJJk0pBehA+jmmvAzfKikTVW2b7wVtbbISclhkGUoJCh7UojnYNCm5Bbar4MZ+w8lfyLChyFeqazWYzysqjWn1F73EuhFPNvXiCIxPrZ7OJg2lyiYyASCmo46irT60pJerZ0DPAFbAShYfKfg/hvEDuF7/nmdscTp7vaLJic7cQm3i2AkMmB+raPM3UfjYgPwpTKuWL93JRUGQk5UigSZKZIoXDPjJaaxK8RuBtRwEEIkOg4Ip6WBT2R0l23tyP6A+YqlnDvvBSFWrE/8qv2DvNtURt9dVBA+WpmJUBKdisDZxzMaqtva2Z6YGejC1h1BPlCxhzDWmKLyacGbzuhSJvp4lOJmTugNaFUZLLdDgmaTQm4pQ+luhEZiT8X468DVWQYrchwkwmk//xCbp7Tu+7vxljDYZbSDCkHQVCKCUE+B9TN74H4B9zaxpychTXPJ5uIrOQhEUkj1ZpSX9qIwzn8dM2FWqrv1qZEgjcbgmKzYvSoUKZAJJzGBxnRQIIwH6bA0hFXiNQCExhigIz+H02KWqWc3Qmg987y9sr81debtsbceUQR3faGCnRT9cc3ROk9x2kOIcKdX9mDYXh4/sbDtTYiyE5r0A0UtfH0roXANipikayb3U0TQxpjOoMCaAmWRJn1DUtpXD1/3TYBVNQvEl3cysCHFBod/UmmuAS9ZG3OH55R4dXkFFvLum70rGZ9RKjTRJ/4pj414JgBky6jIS2/d3Uww4uCoLa6gtmZN49HwUxAe6/3Fdda27lf++ZbCWAXpqYrJ+vBn3XtqgOLoulqlAW3yITsgidjqx3iXzQPzeucSzJRZbb+2X5Ub6ngsuFcJij7A7/NpfApxjcmRR5YlVTlTr9p+ZZChhRKNamWuf8+SU8kguFlCViZ9H2mhhBcWYjAIWRpPAUAwYUDds5lWfDQofZtS7yQIjUmw4UKrQr0Z7WiN05jx/kbPshWSkrrnWeWNwDwrbFtRA9UHEgwNR4l9m/OdKxDcEX4X/CAX9JriurZonM1BfTX2F2D63rT6bdrOdAa7qNUP+s0Y0VZY8DPqsB0QyYBA6wTnfgZNAnISfnENRlyNTv6/C/6pULFkDztPPRHPThrWRf3ye/n9QrBN2Co6bFkPJ+aRPZhNe4cKAVMBO32Olh6htM8+liWjDeAcKSyoDBWVNYIEt2c5Xg3XHZdpc9L2rNhtypDcXVpjXP/kJ/XZBXojfgQ+SqoWOK0xH+XmVVA8ltNxF4BqgfWLp/dYiaciWTrsj8sazKjhlndiGR7B8oIZ7WbhU0u7+gOsVRQHaFWvZP0CHQvVbObXw4FvtVWgaC6ONztmcFwE4rhYaM+Ju7mcUCY7zCNAL8+AJ0Mxl8fNtkpMXnkt2+5W+ciFHgI2Yv32A55ZHEJJnpwYcwPdlMYGGMCMGCSqGSIb3DQEJFTEWBBRrNhuGTGeWAbZS/jh/YfzZMDwDJzBfBgkqhkiG9w0BCRQxUh5QADYAYgAzADYAMQBiADgANgA0AGMANgA3ADkANgAwADEAYgA2ADUAMgBmAGUAMwA4ADcAZgA2ADEAZgBjAGQAOQAzADAAMwBjADAAMwAyADcAAAAAMIAGCSqGSIb3DQEHBqCAMIACAQAwgAYJKoZIhvcNAQcBMCgGCiqGSIb3DQEMAQYwGgQU5vJcSheCI7r7SLHaZyY7j3lBctcCAgQAoIAEggcokn/1oGk1ZlYLNjFGH1ji2TTrHVUGsVGOcxr9q04HOdQnFWEpA9j3yUGKoBO9MaWUNAiQlAYVUY1JPncr2fdw5bZvWFoQrokox9eUAd2PTMgekUTqjRPv3Mx4/0ej16Wbs0DOTO28iHmUFS8h+dgV5WZQ92EjsQk40rYSCFet6E1GUVAboEVH9T6oVNP8JoHzxmqMiPbmtCqZNlJ3VWbKS1FM1o/8FI+7GKfJJw4+u0lqItpRODHsnboyvDsKqMMOk1Wj9ORH5wTkRRxnELuAemgu5s68SktPv5JDw1O9sUYJrhUnymwG8uyB2fByuudvvGHopU+6iZt7bTYvg8r13JheN/BnYqzzA33U1DIf9LahGqtH7fqNXZzT2BKubqgIZMPDCrx3CisbsUGTV8y7BbYvaD7QZdZrdQnNGrnR7C0bZSr4xUfPjkB/CCi5m6h7jT6FhTH8FU7wY7jpN3/H4fqL0eYw82FAfctcmNk5RLsLbeZ9E8nnhdnF/lIjGmOZJiJGli9BnXfylfvpdTxSQ45vfJsCokLczAZ72Mmvrqg67KvfoKfAjPqIcpTkfqrAZ4d3mNVxx0+bHxUdnLPgg7pp9FfVWZnWClKhV/tjgQ5Dj1tbRH69PnbNdRhpQarZksPE/nDamBQwbFSHAI93D5VTeDElrzuZ7j3T5K/rf8p1aEq4LWSuEMSC16UL7lSwXnan+bHujmviCcx9CdoN1+wDICtKKrWqsyFZoB6LtFdsgSVDQ6zalMGI+0M7c1l8pd92fZON19R9LeSfIQRXpNtYUiEDGlNEFILrZuh1klzLxxbpx7y+S9qPVzhlpoYuDMEbLgv0nPTPz+4LlL8DCx+2v/0cMzjKQbcJ016Vzs0rL5bS1gwb2aZ0ldT4fOSGyUP42YVHxpOw71qcymHmomiNZR9OXaJmarND3bl4ugsbrFPFGsBz1+p7SIwIjCicOj5km2SqYLIdQIubdfLHONtE3J50/NyfUmhySVt3ovdzlEZXpSJw6vGQzRPTr1jxOkLKBRaZ9KymyG/tXMnfRXaiKQ1nh/GZ4S5dlmQCx5YxocYSMavL+HgaBUTSuPM4qs86GRVG9lS/2Vkh9ft/2ufrxUFS9rVPeX8f+saCfDHVlu3P7FLYy/t5pXpnGMh/AjpPAf+wRsxg7xlUPgbfQlvMFzISQCsJawNkyZfoLoxwTilySNNpfMZeigTgHO2gporSosahc5ikTYK+HJLIJNhcnfwmmv+VkdpAZ8nEX8Olxqo6mgVbmNkgAOQUhtva9BkCNx072RgdqHSGm9KFvZD7Jtb6XGZZRFUNM0DNqvMM7rYBfv51o8N6t6corCcOmAJQZ77+nNc6ozF/ZIy8Uy5zRs6Mwa7C9LQ3TiAL7NZHjvA4xnkQ/Srszu6uvKB43VjzPC14pyeWnFVYJbEDf7V4LWU1UZMSRfq+ird7VKgS4AW4CXXsiJfjYkZKHEeYtvnveMAeXlUFWhintyIS8HOU9/e+t2WjTciaXvra1L/YzbKGjri1ECdCUhigFMttCGx/G2PJOcfMNFugz62bJrt6RWMr12WeqpWXGKOqIHaPbTvudnOC0jjD8sBLK2AvFsKujFTfkxOyoTl6BF3zgdSh00qef/xFwhTCNYFSQSQJGFGjw8RhvjAZzow9w37ccN1nUoZopw1aoeimrHKf3s5M6VUhsrpvtphPabIGd5BGTefJKKAUeR0t6BdettRyWT3AsjjM95eDKrcfioCBBPJHOpVdD3YY5o3RawoHLCYCSs8KUaNfTxIv/2/ZQVYQJFTFjLGvjj6WD0qmrCkscEHFRDH++XmJYfuBilF4YLNDC01qJUQdEPATOpSFyVSfJM9oh9LLE0QqC2LfxmxmSBxfNw0ISvACjto1G7xTYYP242DlqL2kqeGuZSYGFpQZIyXzAzYWeotdBjJD3hgGjuuP6wDw5Jyat8U6L1KutYkGDowrxC380rXbRCfbLY5rZvQkHXgXmLHNunyXrM4kqWFwJLPTapptXmkClye8+9O+DfsXkW/rQ8qSWeZnOVPCb3PTIwDAksPpRxjuy4V36z8Vl2GeePSGHWTVxGt383AR50kc5bR1ERw8A4gv6px1g5HWIjnIkP9kIYrvprP4x1rQ0T+B/Tmbf+nMb/oFIs4YQsl+3GlSYph0dAnSx3oaRhFSurU/cTgjPs3nnRTkKc+XX7A5snLtnthD4ZLwO14sPcvHwPAFyEAJXwNTpLbetQpCNUZjUg/id1bGSsp22Q9BaT/GeQyCtEGnRn/UBBLTckoULZi75C2XigUxjrr3o2aGlKJK/CQ01Z25y4G9eYslgLGexuRZs8Lijnx5kznyX7hQEz0wOfQ6DUZH4YMIzsIQa9W06v5GKNRcevZMG+wCfUEtR7yrZzn9TmzregOPGu780WwQt33HZ27Weza5/nI26gaphTYAAAAAAAAAAAAAAAAwPTAhMAkGBSsOAwIaBQAEFOy6U+YkvM72T+xeraexxa7kiKq9BBQctlNgZGGVCnKyqLcEv7BtQC2u/QICBAA=\",\n\t\t\"password\":\"Qwerty12\",\n\t\t\"xml\": \"<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\"?><soap:Envelope xmlns:soap=\\\"http://schemas.xmlsoap.org/soap/envelope/\\\" xmlns:wsu=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\\\"><soap:Body><root><name>NCANode</name></root></soap:Body></soap:Envelope>\",\n\t\t\"createTsp\": true,\n\t\t\"useTsaPolicy\": \"TSA_GOST_POLICY\"\n\t}\n}"
+				},
+				"url": {
+					"raw": "http://127.0.0.1:14579",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "14579"
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "XML.verify",
 			"request": {
 				"method": "POST",
@@ -80,6 +110,36 @@
 				"body": {
 					"mode": "raw",
 					"raw": "{\n\t\"version\": \"1.0\",\n\t\"method\": \"XML.verify\",\n\t\"params\": {\n\t\t\"xml\":\"<?xml version=\\\"1.0\\\" encoding=\\\"utf-8\\\" standalone=\\\"no\\\"?><root><name>NCANode</name><ds:Signature xmlns:ds=\\\"http://www.w3.org/2000/09/xmldsig#\\\">\\r\\n<ds:SignedInfo>\\r\\n<ds:CanonicalizationMethod Algorithm=\\\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\\\"/>\\r\\n<ds:SignatureMethod Algorithm=\\\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\\\"/>\\r\\n<ds:Reference URI=\\\"\\\">\\r\\n<ds:Transforms>\\r\\n<ds:Transform Algorithm=\\\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\\\"/>\\r\\n<ds:Transform Algorithm=\\\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments\\\"/>\\r\\n</ds:Transforms>\\r\\n<ds:DigestMethod Algorithm=\\\"http://www.w3.org/2001/04/xmlenc#sha256\\\"/>\\r\\n<ds:DigestValue>ybvg7uzrmIoa6Q02yU8BiLjYNl64fr+yXCtg0kHwdv4=</ds:DigestValue>\\r\\n</ds:Reference>\\r\\n</ds:SignedInfo>\\r\\n<ds:SignatureValue>\\r\\niAo6o5tfMBmXAxOxNTPVZGgjBebA9+taJyywl+h8e992FJYOBr84w92RSk9gwG+VAZXrHaSVsIo5\\r\\ngirvJVwNfDwIyX0to2z5d2/XRa780uNMHTR3oF5RQ97miZqDemBu7PVwG1ayEOMIrmdbnl8+Qr8G\\r\\n19I/CaSmViifwt/XGBalIZxIdFNjT6v0NIPizDLlJcHL8tNe73Sjj4f5Ux11oYQ/Ml8l7UhVtYOw\\r\\nsz/rWIwXqAYocXilUno0CwVKTR26JfIJELyBmrn+9aKXDdusrGfc+T+2ADKVd/52G656Pe2fDghd\\r\\nKfSRBfpSO1UrZLWBsiMAybQEkgvz7VgGjfmixA==\\r\\n</ds:SignatureValue>\\r\\n<ds:KeyInfo>\\r\\n<ds:X509Data>\\r\\n<ds:X509Certificate>\\r\\nMIIGZTCCBE2gAwIBAgIUFX1cSXpU/SdXs4r74PS8YFuVbAowDQYJKoZIhvcNAQELBQAwUjELMAkG\\r\\nA1UEBhMCS1oxQzBBBgNVBAMMOtKw0JvQotCi0KvSmiDQmtCj05jQm9CQ0J3QlNCr0KDQo9Co0Ksg\\r\\n0J7QoNCi0JDQm9Cr0pogKFJTQSkwHhcNMTgwODIyMTIxMTM2WhcNMTkwODIyMTIxMTM2WjCBpzEe\\r\\nMBwGA1UEAwwV0KLQldCh0KLQntCSINCi0JXQodCiMRUwEwYDVQQEDAzQotCV0KHQotCe0JIxGDAW\\r\\nBgNVBAUTD0lJTjEyMzQ1Njc4OTAxMTELMAkGA1UEBhMCS1oxFTATBgNVBAcMDNCQ0JvQnNCQ0KLQ\\r\\nqzEVMBMGA1UECAwM0JDQm9Cc0JDQotCrMRkwFwYDVQQqDBDQotCV0KHQotCe0JLQmNCnMIIBIjAN\\r\\nBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtKWLOJf9qCqA6EO/SVtiMuPZ8q3Sg2RjO0dWXqKQ\\r\\nRP7BWhIyMucMv+WmpRs8RuJ987Hm3B/JszSdiPrmtA9BpIERKphRwp3n4QR6pfLUBEp+5QNetNsv\\r\\n+dbiPcefWCzgJZCqEZVbPvSkiFH20y13YQ2FhEBUp4lLOqydBD2CsDVoTusvLanEgR+AdziJPq2+\\r\\niXwhttpNPShKRTXGbGkxUa4P7YMUCUqWstR7svLaJqxKDMhaR7MpEt56a2pfntm5oFxKNFoBQjRX\\r\\nKbiBNIKciMRAeznjezv9ZA98WzWPIMuWzi38fPW5X7IVqa7ZbAFWvZIHWJmrl57uKGBNd9EUewID\\r\\nAQABo4IB2zCCAdcwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggqgw4DAwQB\\r\\nATAPBgNVHSMECDAGgARbanQRMB0GA1UdDgQWBBRrNhuGTGeWAbZS/jh/YfzZMDwDJzBeBgNVHSAE\\r\\nVzBVMFMGByqDDgMDAgQwSDAhBggrBgEFBQcCARYVaHR0cDovL3BraS5nb3Yua3ovY3BzMCMGCCsG\\r\\nAQUFBwICMBcMFWh0dHA6Ly9wa2kuZ292Lmt6L2NwczBWBgNVHR8ETzBNMEugSaBHhiFodHRwOi8v\\r\\nY3JsLnBraS5nb3Yua3ovbmNhX3JzYS5jcmyGImh0dHA6Ly9jcmwxLnBraS5nb3Yua3ovbmNhX3Jz\\r\\nYS5jcmwwWgYDVR0uBFMwUTBPoE2gS4YjaHR0cDovL2NybC5wa2kuZ292Lmt6L25jYV9kX3JzYS5j\\r\\ncmyGJGh0dHA6Ly9jcmwxLnBraS5nb3Yua3ovbmNhX2RfcnNhLmNybDBiBggrBgEFBQcBAQRWMFQw\\r\\nLgYIKwYBBQUHMAKGImh0dHA6Ly9wa2kuZ292Lmt6L2NlcnQvbmNhX3JzYS5jZXIwIgYIKwYBBQUH\\r\\nMAGGFmh0dHA6Ly9vY3NwLnBraS5nb3Yua3owDQYJKoZIhvcNAQELBQADggIBACy0Lxj0D/q3SwUz\\r\\n0X9BICyKPw/U6sXmedqUcrghzZuT9ojnUp9w7g4ndZOKTRRxQyLiUYb9neJ3SGVuF/XYcs7Ovrp5\\r\\nRGNNHuVUR8bQz9cbWd/O2qRUY6qlg4ZSjYsjFYaQm8o+uO56PuqWG125O7XNUdAUHNBc2hUrrngG\\r\\nKU0FKxlBygxLpvTf4I9q3QA0PJ6MnHrUKlor4sRGar4hMJCbrxeMG4pv3Jx/r9fsKy7f+yZeQo3T\\r\\n4XAIXmUTXF8UC3HtIroxAP6yEoEhG76oS3qvYc1K/krI48ju5VYxmzEabNqRhiiEBpocIwCqFLLo\\r\\n9x3CKuUkuA7pwEib4YcCNxCTucCtd9x8dGgZRNffJV4de/Aja/VP84q8rxmcyogbUQzvPb+2/zKR\\r\\nh6cxYxnRsuL4wWUV+fxp/usy0mJMboQF7IcRFe1fXosU0RWYmKHITOCDbs0NKxTn7TSxEKMYdJN6\\r\\nYngCmKlmwR/+AfxhN1QMSQpU/m8Glwl+f5wZIL5MQJVhrrWIteh0tnb+OuDQHz4g2vmD2xq5jUQD\\r\\nFIrjXOdy4zToqM6tirt3nGDsblWgcgsPac50FLT1+um7W26UsmtZ9/wXvkxYC9kL5gUX53VD/bcK\\r\\nki8fogjrNoYEZiORRqmwvZ5EVe4w3Hfb7YCnc3NzhhIg6hqmzumXNCgLCt2q\\r\\n</ds:X509Certificate>\\r\\n</ds:X509Data>\\r\\n</ds:KeyInfo>\\r\\n</ds:Signature></root>\"\n\t}\n}"
+				},
+				"url": {
+					"raw": "http://127.0.0.1:14579",
+					"protocol": "http",
+					"host": [
+						"127",
+						"0",
+						"0",
+						"1"
+					],
+					"port": "14579"
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "XML.verifyWithSecurityHeader",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"name": "Content-Type",
+						"value": "application/json",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"version\": \"1.0\",\n\t\"method\": \"XML.verifyWithSecurityHeader\",\n\t\"params\": {\n\t\t\"xml\":\"<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\" standalone=\\\"no\\\"?><soap:Envelope xmlns:soap=\\\"http://schemas.xmlsoap.org/soap/envelope/\\\" xmlns:wsu=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd\\\"><soap:Header><wsse:Security xmlns:wsse=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd\\\" soap:mustUnderstand=\\\"1\\\"><ds:Signature xmlns:ds=\\\"http://www.w3.org/2000/09/xmldsig#\\\">\\r\\n<ds:SignedInfo>\\r\\n<ds:CanonicalizationMethod Algorithm=\\\"http://www.w3.org/2001/10/xml-exc-c14n#\\\"/>\\r\\n<ds:SignatureMethod Algorithm=\\\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\\\"/>\\r\\n<ds:Reference URI=\\\"#id-0906eabb-22f1-4cfa-81e3-6afa3d65b9d2\\\">\\r\\n<ds:Transforms>\\r\\n<ds:Transform Algorithm=\\\"http://www.w3.org/2001/10/xml-exc-c14n#\\\"/>\\r\\n</ds:Transforms>\\r\\n<ds:DigestMethod Algorithm=\\\"http://www.w3.org/2001/04/xmlenc#sha256\\\"/>\\r\\n<ds:DigestValue>4jWuwoTuESph6fW54OZmsXswIUVrLhhY1+T0lLt5MUQ=</ds:DigestValue>\\r\\n</ds:Reference>\\r\\n</ds:SignedInfo>\\r\\n<ds:SignatureValue>\\r\\npGF3+eQPTMl5oadeHwNJZNM7pId3ZotQ7YjyQsbRwg9HiGwNsTKqDYZNIRGHyw4Pgzmm1+626S3N&#13;\\r\\nYWUF77sZRoKkdw8QW1C4aXfhJ9x1NH/pyxojusqOMcnw8YtLvtFShI6l6IeawLKwYQH3PIkvY93j&#13;\\r\\nZA7V7R8yCGm0bAR2TL+/ISHroxGPeX0UCvnwpga1mMOgH7p87YnVgIxnJBmbICL0S4s0EllujrNs&#13;\\r\\n/ZTxI/UOD28RQwB7ghYs5X2ahMRvRQiILKnww/e+lGK6Ez//WboA1ysYfhPPm/2vBw+WvADTT2Wa&#13;\\r\\n+7yZ6JMHAMD2bQjWF1lZbvjJohlwmU1qNokX6A==\\r\\n</ds:SignatureValue>\\r\\n<ds:KeyInfo>\\r\\n<wsse:SecurityTokenReference><wsse:KeyIdentifier EncodingType=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary\\\" ValueType=\\\"http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3\\\">MIIGZTCCBE2gAwIBAgIUFX1cSXpU/SdXs4r74PS8YFuVbAowDQYJKoZIhvcNAQELBQAwUjELMAkGA1UEBhMCS1oxQzBBBgNVBAMMOtKw0JvQotCi0KvSmiDQmtCj05jQm9CQ0J3QlNCr0KDQo9Co0Ksg0J7QoNCi0JDQm9Cr0pogKFJTQSkwHhcNMTgwODIyMTIxMTM2WhcNMTkwODIyMTIxMTM2WjCBpzEeMBwGA1UEAwwV0KLQldCh0KLQntCSINCi0JXQodCiMRUwEwYDVQQEDAzQotCV0KHQotCe0JIxGDAWBgNVBAUTD0lJTjEyMzQ1Njc4OTAxMTELMAkGA1UEBhMCS1oxFTATBgNVBAcMDNCQ0JvQnNCQ0KLQqzEVMBMGA1UECAwM0JDQm9Cc0JDQotCrMRkwFwYDVQQqDBDQotCV0KHQotCe0JLQmNCnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtKWLOJf9qCqA6EO/SVtiMuPZ8q3Sg2RjO0dWXqKQRP7BWhIyMucMv+WmpRs8RuJ987Hm3B/JszSdiPrmtA9BpIERKphRwp3n4QR6pfLUBEp+5QNetNsv+dbiPcefWCzgJZCqEZVbPvSkiFH20y13YQ2FhEBUp4lLOqydBD2CsDVoTusvLanEgR+AdziJPq2+iXwhttpNPShKRTXGbGkxUa4P7YMUCUqWstR7svLaJqxKDMhaR7MpEt56a2pfntm5oFxKNFoBQjRXKbiBNIKciMRAeznjezv9ZA98WzWPIMuWzi38fPW5X7IVqa7ZbAFWvZIHWJmrl57uKGBNd9EUewIDAQABo4IB2zCCAdcwDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggqgw4DAwQBATAPBgNVHSMECDAGgARbanQRMB0GA1UdDgQWBBRrNhuGTGeWAbZS/jh/YfzZMDwDJzBeBgNVHSAEVzBVMFMGByqDDgMDAgQwSDAhBggrBgEFBQcCARYVaHR0cDovL3BraS5nb3Yua3ovY3BzMCMGCCsGAQUFBwICMBcMFWh0dHA6Ly9wa2kuZ292Lmt6L2NwczBWBgNVHR8ETzBNMEugSaBHhiFodHRwOi8vY3JsLnBraS5nb3Yua3ovbmNhX3JzYS5jcmyGImh0dHA6Ly9jcmwxLnBraS5nb3Yua3ovbmNhX3JzYS5jcmwwWgYDVR0uBFMwUTBPoE2gS4YjaHR0cDovL2NybC5wa2kuZ292Lmt6L25jYV9kX3JzYS5jcmyGJGh0dHA6Ly9jcmwxLnBraS5nb3Yua3ovbmNhX2RfcnNhLmNybDBiBggrBgEFBQcBAQRWMFQwLgYIKwYBBQUHMAKGImh0dHA6Ly9wa2kuZ292Lmt6L2NlcnQvbmNhX3JzYS5jZXIwIgYIKwYBBQUHMAGGFmh0dHA6Ly9vY3NwLnBraS5nb3Yua3owDQYJKoZIhvcNAQELBQADggIBACy0Lxj0D/q3SwUz0X9BICyKPw/U6sXmedqUcrghzZuT9ojnUp9w7g4ndZOKTRRxQyLiUYb9neJ3SGVuF/XYcs7Ovrp5RGNNHuVUR8bQz9cbWd/O2qRUY6qlg4ZSjYsjFYaQm8o+uO56PuqWG125O7XNUdAUHNBc2hUrrngGKU0FKxlBygxLpvTf4I9q3QA0PJ6MnHrUKlor4sRGar4hMJCbrxeMG4pv3Jx/r9fsKy7f+yZeQo3T4XAIXmUTXF8UC3HtIroxAP6yEoEhG76oS3qvYc1K/krI48ju5VYxmzEabNqRhiiEBpocIwCqFLLo9x3CKuUkuA7pwEib4YcCNxCTucCtd9x8dGgZRNffJV4de/Aja/VP84q8rxmcyogbUQzvPb+2/zKRh6cxYxnRsuL4wWUV+fxp/usy0mJMboQF7IcRFe1fXosU0RWYmKHITOCDbs0NKxTn7TSxEKMYdJN6YngCmKlmwR/+AfxhN1QMSQpU/m8Glwl+f5wZIL5MQJVhrrWIteh0tnb+OuDQHz4g2vmD2xq5jUQDFIrjXOdy4zToqM6tirt3nGDsblWgcgsPac50FLT1+um7W26UsmtZ9/wXvkxYC9kL5gUX53VD/bcKki8fogjrNoYEZiORRqmwvZ5EVe4w3Hfb7YCnc3NzhhIg6hqmzumXNCgLCt2q</wsse:KeyIdentifier></wsse:SecurityTokenReference>\\r\\n</ds:KeyInfo>\\r\\n</ds:Signature></wsse:Security></soap:Header><soap:Body wsu:Id=\\\"id-0906eabb-22f1-4cfa-81e3-6afa3d65b9d2\\\"><root><name>NCANode</name></root></soap:Body></soap:Envelope>\"\n\t}\n}"
 				},
 				"url": {
 					"raw": "http://127.0.0.1:14579",

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.apache.ws.security</groupId>
       <artifactId>wss4j</artifactId>
-      <version>1.5.11</version>
+      <version>1.6.19</version>
     </dependency>
     <dependency>
       <groupId>org.apache.wss4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.apache.santuario</groupId>
       <artifactId>xmlsec</artifactId>
-      <version>1.5.8</version>
+      <version>2.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -98,6 +98,27 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ws.security</groupId>
+      <artifactId>wss4j</artifactId>
+      <version>1.5.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wss4j</groupId>
+      <artifactId>wss4j-ws-security-dom</artifactId>
+      <version>2.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.xml.ws</groupId>
+      <artifactId>jakarta.xml.ws-api</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.ws</groupId>
+      <artifactId>jaxws-rt</artifactId>
+      <version>3.0.0</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/kz/ncanode/api/version/v10/ApiVersion10.java
+++ b/src/main/java/kz/ncanode/api/version/v10/ApiVersion10.java
@@ -35,6 +35,7 @@ public class ApiVersion10 implements ApiVersion {
         methods.put("XML.sign", new XMLSign(this, man));
         methods.put("XML.signWithSecurityHeader", new XMLSignWithSecurityHeader(this, man));
         methods.put("XML.verify", new XMLVerify(this, man));
+        methods.put("XML.verifyWithSecurityHeader", new XMLVerifyWithSecurityHeader(this, man));
 
         // TSP
         methods.put("TSP.verify", new TSPVerify(this, man));

--- a/src/main/java/kz/ncanode/api/version/v10/ApiVersion10.java
+++ b/src/main/java/kz/ncanode/api/version/v10/ApiVersion10.java
@@ -33,6 +33,7 @@ public class ApiVersion10 implements ApiVersion {
 
         // XML
         methods.put("XML.sign", new XMLSign(this, man));
+        methods.put("XML.signWithSecurityHeader", new XMLSignWithSecurityHeader(this, man));
         methods.put("XML.verify", new XMLVerify(this, man));
 
         // TSP

--- a/src/main/java/kz/ncanode/api/version/v10/methods/XMLSignWithSecurityHeader.java
+++ b/src/main/java/kz/ncanode/api/version/v10/methods/XMLSignWithSecurityHeader.java
@@ -1,0 +1,190 @@
+package kz.ncanode.api.version.v10.methods;
+
+import kz.gov.pki.kalkan.jce.provider.cms.CMSSignedData;
+import kz.ncanode.Helper;
+import kz.ncanode.api.ApiServiceProvider;
+import kz.ncanode.api.core.ApiArgument;
+import kz.ncanode.api.core.ApiMethod;
+import kz.ncanode.api.core.ApiVersion;
+import kz.ncanode.api.exceptions.ApiErrorException;
+import kz.ncanode.api.version.v10.arguments.*;
+import org.apache.wss4j.dom.WSConstants;
+import org.apache.wss4j.dom.message.WSSecHeader;
+import org.apache.xml.security.c14n.Canonicalizer;
+import org.apache.xml.security.signature.XMLSignature;
+import org.apache.xml.security.transforms.Transforms;
+import org.apache.xml.security.utils.XMLUtils;
+import org.json.simple.JSONObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import jakarta.xml.soap.*;
+import javax.xml.namespace.QName;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Enumeration;
+import java.util.UUID;
+
+public class XMLSignWithSecurityHeader extends ApiMethod {
+    public XMLSignWithSecurityHeader(ApiVersion ver, ApiServiceProvider man) {
+        super(ver, man);
+    }
+
+    @Override
+    public JSONObject handle() throws ApiErrorException {
+        KeyStore p12 = (KeyStore) args.get(0).get();
+        Document xml = (Document) args.get(1).get();
+
+        String rawDocument = "";
+
+        try {
+            StringWriter os = new StringWriter();
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer trans = tf.newTransformer();
+            trans.transform(new DOMSource(xml), new StreamResult(os));
+            os.close();
+            rawDocument = os.toString();
+        } catch (Exception e) {
+            throw new ApiErrorException(e.getMessage());
+        }
+
+        // todo Добавить возможность выбора алиаса
+        Enumeration<String> als = null;
+        try {
+            als = p12.aliases();
+        } catch (KeyStoreException e) {
+            throw new ApiErrorException(e.getMessage());
+        }
+        String alias = null;
+        while (als.hasMoreElements()) {
+            alias = als.nextElement();
+        }
+
+        // get private key
+        PrivateKey privateKey;
+        try {
+            String password = ((P12ApiArgument) args.get(0)).getPassword();
+            privateKey = (PrivateKey) p12.getKey(alias, password.toCharArray());
+        } catch (Exception e) {
+            throw new ApiErrorException(e.getMessage());
+        }
+
+        // get cert
+        X509Certificate cert = null;
+        try {
+            cert = (X509Certificate) p12.getCertificate(alias);
+        } catch (KeyStoreException e) {
+            throw new ApiErrorException(e.getMessage());
+        }
+
+        String[] alg = Helper.getSignMethodByOID(cert.getSigAlgOID());
+        String signMethod = alg[0];
+        String digestMethod = alg[1];
+
+        InputStream is = new ByteArrayInputStream(rawDocument.getBytes());
+
+        String result = "";
+
+        try {
+            // sign a soap request according to a reference implementation from smartbridge
+            SOAPMessage msg = MessageFactory.newInstance().createMessage(null, is);
+            SOAPEnvelope env = msg.getSOAPPart().getEnvelope();
+            SOAPBody body = env.getBody();
+
+            String bodyId = "id-" + UUID.randomUUID().toString();
+            body.addAttribute(new QName(WSConstants.WSU_NS, "Id", WSConstants.WSU_PREFIX), bodyId);
+
+            SOAPHeader header = env.getHeader();
+            if (header == null) {
+                header = env.addHeader();
+            }
+
+            Document doc = env.getOwnerDocument();
+
+            Transforms transforms = new Transforms(env.getOwnerDocument());
+            transforms.addTransform(Transforms.TRANSFORM_C14N_EXCL_OMIT_COMMENTS);
+
+            Element c14nMethod = XMLUtils.createElementInSignatureSpace(doc, "CanonicalizationMethod");
+            c14nMethod.setAttributeNS(null, "Algorithm", Canonicalizer.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+
+            Element signatureMethod = XMLUtils.createElementInSignatureSpace(doc, "SignatureMethod");
+            signatureMethod.setAttributeNS(null, "Algorithm", signMethod);
+
+            XMLSignature sig = new XMLSignature(doc, "", signatureMethod, c14nMethod);
+            sig.addDocument("#" + bodyId, transforms, digestMethod);
+            sig.getSignedInfo().getSignatureMethodElement().setNodeValue(Transforms.TRANSFORM_C14N_EXCL_OMIT_COMMENTS);
+
+            WSSecHeader secHeader = new org.apache.wss4j.dom.message.WSSecHeader(doc);
+            secHeader.setMustUnderstand(true);
+            secHeader.insertSecurityHeader();
+            header.appendChild(secHeader.getSecurityHeaderElement());
+            header.getFirstChild().appendChild(sig.getElement());
+
+            org.apache.ws.security.message.token.SecurityTokenReference reference = new org.apache.ws.security.message.token.SecurityTokenReference(doc);
+            reference.setKeyIdentifier(cert);
+
+            sig.getKeyInfo().addUnknownElement(reference.getElement());
+            sig.sign(privateKey);
+
+            StringWriter os = new StringWriter();
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer trans = tf.newTransformer();
+            trans.transform(new DOMSource(doc), new StreamResult(os));
+            os.close();
+            result = os.toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ApiErrorException(e.getMessage());
+        } catch (Throwable e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            throw e;
+        }
+
+        JSONObject resp = new JSONObject();
+        resp.put("xml", result);
+        resp.put("raw", rawDocument);
+
+        // Create TSP Sign
+        if ((Boolean) args.get(2).get()) {
+            String useTsaPolicy = (String) args.get(3).get();
+            String tspHashAlgorithm = (String) args.get(4).get();
+
+            try {
+                CMSSignedData tsp = man.tsp.createTSP(rawDocument.getBytes(), tspHashAlgorithm, useTsaPolicy).toCMSSignedData();
+
+                // encode tsp to Base64
+                String tspBase64 = new String(Base64.getEncoder().encode(tsp.getEncoded()));
+                resp.put("tsp", tspBase64);
+
+            } catch (Exception e) {
+                throw new ApiErrorException(e.getMessage());
+            }
+        }
+
+        return resp;
+    }
+
+    @Override
+    public ArrayList<ApiArgument> arguments() {
+        ArrayList<ApiArgument> args = new ArrayList<>();
+        args.add(new P12ApiArgument(true, ver, man));
+        args.add(new XmlArgument(true, ver, man));
+
+        // tsp arguments
+        args.add(new CreateTspArgument(false, ver, man));
+        args.add(new UseTsaPolicyArgument(false, ver, man));
+        args.add(new TspHashAlgorithmArgument(false, ver, man));
+        return args;
+    }
+}

--- a/src/main/java/kz/ncanode/api/version/v10/methods/XMLVerifyWithSecurityHeader.java
+++ b/src/main/java/kz/ncanode/api/version/v10/methods/XMLVerifyWithSecurityHeader.java
@@ -1,0 +1,141 @@
+package kz.ncanode.api.version.v10.methods;
+
+import jakarta.xml.soap.MessageFactory;
+import jakarta.xml.soap.SOAPEnvelope;
+import jakarta.xml.soap.SOAPMessage;
+import kz.ncanode.api.ApiServiceProvider;
+import kz.ncanode.api.core.ApiArgument;
+import kz.ncanode.api.core.ApiMethod;
+import kz.ncanode.api.core.ApiVersion;
+import kz.ncanode.api.exceptions.ApiErrorException;
+import kz.ncanode.api.version.v10.arguments.VerifyCrlArgument;
+import kz.ncanode.api.version.v10.arguments.VerifyOcspArgument;
+import kz.ncanode.api.version.v10.arguments.XmlArgument;
+import org.apache.ws.security.components.crypto.CertificateStore;
+import org.apache.ws.security.message.token.SecurityTokenReference;
+import org.apache.xml.security.signature.XMLSignature;
+import org.json.simple.JSONObject;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+
+public class XMLVerifyWithSecurityHeader extends ApiMethod {
+    public XMLVerifyWithSecurityHeader(ApiVersion ver, ApiServiceProvider man) {
+        super(ver, man);
+    }
+
+    @Override
+    public JSONObject handle() throws ApiErrorException {
+        Document xml = (Document) args.get(0).get();
+
+        String rawDocument = "";
+
+        try {
+            StringWriter os = new StringWriter();
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer trans = tf.newTransformer();
+            trans.transform(new DOMSource(xml), new StreamResult(os));
+            os.close();
+            rawDocument = os.toString();
+        } catch (Exception e) {
+            throw new ApiErrorException(e.getMessage());
+        }
+
+        InputStream is = new ByteArrayInputStream(rawDocument.getBytes());
+
+        try {
+            SOAPMessage msg = MessageFactory.newInstance().createMessage(null, is);
+            SOAPEnvelope env = msg.getSOAPPart().getEnvelope();
+            xml = env.getOwnerDocument();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new ApiErrorException(e.getMessage());
+        } catch (Throwable e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+            throw e;
+        }
+
+        Element rootEl = (Element) xml.getFirstChild();
+        NodeList list = rootEl.getElementsByTagName("ds:Signature");
+
+        X509Certificate cert;
+        boolean result = false;
+
+        try {
+            Node sigNode = list.item(0);
+            XMLSignature signature = new XMLSignature((Element) sigNode, "");
+            NodeList securityRef = rootEl.getElementsByTagName("wsse:SecurityTokenReference");
+            SecurityTokenReference ref = new SecurityTokenReference((Element) securityRef.item(0));
+            cert = ref.getKeyIdentifier(new CertificateStore(new X509Certificate[]{}))[0];
+
+            if (cert != null) {
+                result = signature.checkSignatureValue(cert.getPublicKey());
+            }
+
+        } catch (Exception e) {
+            throw new ApiErrorException(e.getMessage());
+        }
+
+        JSONObject resp = new JSONObject();
+
+        if (cert != null) {
+            // Chain information
+            ArrayList<X509Certificate> chain = null;
+            ArrayList<JSONObject> chainInf = null;
+            try {
+                chain = man.ca.chain(cert);
+
+                chainInf = new ArrayList<>();
+
+                if (chain != null) {
+                    for (X509Certificate chainCert : chain) {
+                        JSONObject chi = man.pki.certInfo(chainCert, false, false, null);
+                        chainInf.add(chi);
+                    }
+                }
+            } catch (Exception e) {
+                throw new ApiErrorException(e.getMessage());
+            }
+
+            X509Certificate issuerCert = null;
+
+            if (chain != null && chain.size() > 1) {
+                issuerCert = chain.get(1);
+            }
+
+            try {
+                JSONObject certInf;
+                certInf = man.pki.certInfo(cert, ((boolean) args.get(1).get() && issuerCert != null), ((boolean) args.get(2).get() && issuerCert != null), issuerCert);
+                certInf.put("chain", chainInf);
+                resp.put("cert", certInf);
+            } catch (Exception e) {
+                throw new ApiErrorException(e.getMessage());
+            }
+        }
+
+        resp.put("valid", result);
+
+        return resp;
+    }
+
+    @Override
+    public ArrayList<ApiArgument> arguments() {
+        ArrayList<ApiArgument> args = new ArrayList<>();
+        args.add(new XmlArgument(true, ver, man));
+        args.add(new VerifyOcspArgument(false, ver, man));
+        args.add(new VerifyCrlArgument(false, ver, man));
+        return args;
+    }
+}


### PR DESCRIPTION
Добавил метод, который подписывает запросы в формате, описанном в https://github.com/malikzh/NCANode/issues/69

Ключевое отличие от существующего метода XMLSign в том, что метод добавляет элемент wsse:Security с информацией о подписи.

Готов обсудить реализацию. Возможно, вместо добавления нового метода стоит просто обновить XMLSign, но не хочется ломать совместимость.