### PR TITLE
перехват ошибок и возврат корректных http кодов

### DIFF
--- a/src/main/java/kz/ncanode/api/core/ApiController.java
+++ b/src/main/java/kz/ncanode/api/core/ApiController.java
@@ -8,6 +8,7 @@ import org.json.simple.JSONObject;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
 
 public abstract class ApiController extends ApiDependencies {
 
@@ -36,9 +37,12 @@ public abstract class ApiController extends ApiDependencies {
             if (am.url().equals(methodName)) {
                 try {
                     invokeMethod(m, request, response);
+                } catch (InvalidArgumentException e) {
+                    throw new ApiErrorException(e.getMessage(), HttpURLConnection.HTTP_BAD_REQUEST);
                 } catch (Exception e) {
+                    // TODO заменить printStackTrace на нормальное логирование в json
                     e.printStackTrace();
-                    throw new ApiErrorException(e.getCause().getMessage());
+                    throw new ApiErrorException(e.getMessage());
                 }
                 break;
             }

--- a/src/main/java/kz/ncanode/api/core/ApiStatus.java
+++ b/src/main/java/kz/ncanode/api/core/ApiStatus.java
@@ -13,5 +13,6 @@ public class ApiStatus {
     public final static int STATUS_API_ERROR             = 5; // Внутренняя ошибка API
     public final static int STATUS_PARAMS_NOT_FOUND      = 6; // Параметр "params" отсутствует
     public final static int STATUS_METHOD_NOT_SPECIFIED  = 7; // Метод не указан
+    public final static int STATUS_REQUEST_PARSE_ERROR  = -1; // Ошибка парсинга запроса
 
 }

--- a/src/main/java/kz/ncanode/api/exceptions/ApiErrorException.java
+++ b/src/main/java/kz/ncanode/api/exceptions/ApiErrorException.java
@@ -1,8 +1,24 @@
 package kz.ncanode.api.exceptions;
 
+import java.net.HttpURLConnection;
+
 public class ApiErrorException extends Exception {
+    protected int httpCode;
+
     public ApiErrorException(String message) {
         super(message);
+
+        this.httpCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
+    }
+
+    public ApiErrorException(String message, int httpCode) {
+        super(message);
+
+        this.httpCode = httpCode;
+    }
+
+    public int getHttpCode() {
+        return httpCode;
     }
 
     public ApiErrorException() {

--- a/src/main/java/kz/ncanode/api/version/v20/ApiVersion20.java
+++ b/src/main/java/kz/ncanode/api/version/v20/ApiVersion20.java
@@ -2,18 +2,16 @@ package kz.ncanode.api.version.v20;
 
 import kz.ncanode.api.ApiServiceProvider;
 import kz.ncanode.api.core.ApiController;
-import kz.ncanode.api.core.ApiMethod;
 import kz.ncanode.api.core.ApiStatus;
 import kz.ncanode.api.core.ApiVersion;
 import kz.ncanode.api.exceptions.ApiErrorException;
-import kz.ncanode.api.version.v10.ApiVersion10;
 import kz.ncanode.api.version.v20.controllers.CmsController;
 import kz.ncanode.api.version.v20.controllers.InfoController;
 import kz.ncanode.api.version.v20.controllers.NodeController;
 import org.json.simple.JSONObject;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
 
 /**
@@ -52,10 +50,11 @@ public class ApiVersion20 implements ApiVersion {
         String method = "";
 
         try {
-            method = (String)request.get("method");
+            method = (String) request.get("method");
         } catch (ClassCastException e) {
             JSONObject resp = new JSONObject();
             resp.put("status", ApiStatus.STATUS_INVALID_PARAMETER);
+            resp.put("httpCode", HttpURLConnection.HTTP_BAD_REQUEST);
             resp.put("message", "Invalid parameter \"method\"");
             return resp;
         }
@@ -64,6 +63,7 @@ public class ApiVersion20 implements ApiVersion {
         if (method == null || method.isEmpty()) {
             JSONObject resp = new JSONObject();
             resp.put("status", ApiStatus.STATUS_METHOD_NOT_SPECIFIED);
+            resp.put("httpCode", HttpURLConnection.HTTP_BAD_REQUEST);
             resp.put("message", "\"method\" not specified");
             return resp;
         }
@@ -73,6 +73,7 @@ public class ApiVersion20 implements ApiVersion {
         if (controller == null || !controller.hasMethod(method)) {
             JSONObject resp = new JSONObject();
             resp.put("status", ApiStatus.STATUS_METHOD_NOT_FOUND);
+            resp.put("httpCode", HttpURLConnection.HTTP_BAD_REQUEST);
             resp.put("message", "Method not found");
             return resp;
         }
@@ -81,10 +82,11 @@ public class ApiVersion20 implements ApiVersion {
         JSONObject params;
 
         try {
-            params = (JSONObject)request.get("params");
+            params = (JSONObject) request.get("params");
         } catch (ClassCastException e) {
             JSONObject resp = new JSONObject();
             resp.put("status", ApiStatus.STATUS_INVALID_PARAMETER);
+            resp.put("httpCode", HttpURLConnection.HTTP_BAD_REQUEST);
             resp.put("message", "Invalid parameter \"params\"");
             return resp;
         }
@@ -97,8 +99,10 @@ public class ApiVersion20 implements ApiVersion {
             controller.callMethod(method, params, response);
         } catch (ApiErrorException e) {
             JSONObject resp = new JSONObject();
+            resp.put("httpCode", e.getHttpCode());
             resp.put("status", ApiStatus.STATUS_API_ERROR);
             resp.put("message", "Api error: " + e.getMessage());
+
             return resp;
         }
 

--- a/src/main/java/kz/ncanode/api/version/v20/controllers/CmsController.java
+++ b/src/main/java/kz/ncanode/api/version/v20/controllers/CmsController.java
@@ -63,7 +63,7 @@ public class CmsController extends kz.ncanode.api.core.ApiController {
             sig.initSign(privateKey);
             sig.update(model.data.get());
 
-            CertStore chainStore = CertStore.getInstance("Collection", new CollectionCertStoreParameters(Arrays.asList(cert)),getApiServiceProvider().kalkan.get().getName());
+            CertStore chainStore = CertStore.getInstance("Collection", new CollectionCertStoreParameters(Arrays.asList(cert)), getApiServiceProvider().kalkan.get().getName());
             gen.addSigner(privateKey, cert, Helper.getDigestAlgorithmOidBYSignAlgorithmOid(cert.getSigAlgOID()));
             gen.addCertificatesAndCRLs(chainStore);
         }
@@ -80,10 +80,9 @@ public class CmsController extends kz.ncanode.api.core.ApiController {
 
             List<SignerInformation> newSigners = new ArrayList<SignerInformation>();
 
-            int i=0;
+            int i = 0;
 
-            for (SignerInformation signer : (Collection<SignerInformation>)signerStore.getSigners())
-            {
+            for (SignerInformation signer : (Collection<SignerInformation>) signerStore.getSigners()) {
                 X509Certificate cert = certs.get(i++);
                 newSigners.add(getApiServiceProvider().tsp.addTspToSigner(signer, cert, useTsaPolicy));
             }
@@ -169,7 +168,7 @@ public class CmsController extends kz.ncanode.api.core.ApiController {
 
         JSONArray certsList = new JSONArray();
 
-        for (int i=0; i<certs.size(); ++i) {
+        for (int i = 0; i < certs.size(); ++i) {
             X509Certificate cert = certs.get(i);
 
             // Chain information
@@ -198,7 +197,7 @@ public class CmsController extends kz.ncanode.api.core.ApiController {
 
             try {
                 JSONObject certInf2 = new JSONObject();
-                JSONObject certInf = getApiServiceProvider().pki.certInfo(cert,model.checkOcsp.get(), model.checkCrl.get(), issuerCert);
+                JSONObject certInf = getApiServiceProvider().pki.certInfo(cert, model.checkOcsp.get(), model.checkCrl.get(), issuerCert);
                 certInf2.put("chain", chainInf);
                 certInf2.put("cert", certInf);
                 certsList.add(certInf2);

--- a/src/main/java/kz/ncanode/interaction/interactors/HttpInteractor.java
+++ b/src/main/java/kz/ncanode/interaction/interactors/HttpInteractor.java
@@ -5,6 +5,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import kz.ncanode.api.ApiServiceProvider;
+import kz.ncanode.api.core.ApiStatus;
 import kz.ncanode.info.InfoServiceProvider;
 import kz.ncanode.interaction.InteractionServiceProvider;
 import kz.ncanode.interaction.Interactor;
@@ -13,6 +14,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 import java.io.*;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 
@@ -25,7 +27,7 @@ public class HttpInteractor implements Interactor {
 
     @Override
     public void interact() {
-        String ip   = provider.config.get("http", "ip");
+        String ip = provider.config.get("http", "ip");
         int port = Integer.valueOf(provider.config.get("http", "port"));
 
         provider.out.write("Starting HTTP server on " + ip + ":" + port + "...");
@@ -51,20 +53,22 @@ public class HttpInteractor implements Interactor {
             ApiServiceProvider api = HttpInteractor.this.provider.api;
             InfoServiceProvider info = HttpInteractor.this.provider.info;
 
+            int responseCode = HttpURLConnection.HTTP_OK;
+
             // headers
             Headers headers = exchange.getResponseHeaders();
             headers.add("X-Powered-By", info.getFullName());
 
             // streams
             OutputStream resp = exchange.getResponseBody();
-            InputStream req  = exchange.getRequestBody();
+            InputStream req = exchange.getRequestBody();
 
             // Принимаем только POST запросы
             if (!exchange.getRequestMethod().equals("POST")) {
                 headers.add("Content-Type", "text/plain; charset=UTF-8");
-                String respString = info.getFullName() +" is started. Please use POST request method for work with API.";
+                String respString = info.getFullName() + " is started. Please use POST request method for work with API.";
 
-                exchange.sendResponseHeaders(200, respString.length());
+                exchange.sendResponseHeaders(responseCode, respString.length());
                 resp.write(respString.getBytes());
                 resp.close();
             } else {
@@ -91,19 +95,28 @@ public class HttpInteractor implements Interactor {
 
                     // Process request
                     try {
-                        JSONObject requestJson = (JSONObject)(new JSONParser()).parse(requestBody);
-                        response = api.process(requestJson).toJSONString();
+                        JSONObject requestJson = (JSONObject) (new JSONParser()).parse(requestBody);
+                        JSONObject responseJson = api.process(requestJson);
+                        responseCode = (int) responseJson.getOrDefault("httpCode", responseCode);
+                        response = responseJson.toJSONString();
                     } catch (ParseException e) {
                         JSONObject re = new JSONObject();
-                        re.put("status", -1);
+                        re.put("status", ApiStatus.STATUS_REQUEST_PARSE_ERROR);
                         re.put("message", "JSON parsing error");
                         response = re.toJSONString();
+                        responseCode = HttpURLConnection.HTTP_BAD_REQUEST;
+                    } catch (Exception e) {
+                        JSONObject re = new JSONObject();
+                        re.put("status", ApiStatus.STATUS_API_ERROR);
+                        re.put("message", e.getMessage());
+                        response = re.toJSONString();
+                        responseCode = HttpURLConnection.HTTP_INTERNAL_ERROR;
                     }
                 }
 
                 byte[] respBytes = response.getBytes(StandardCharsets.UTF_8);
 
-                exchange.sendResponseHeaders(200, respBytes.length);
+                exchange.sendResponseHeaders(responseCode, respBytes.length);
                 resp.write(respBytes);
                 resp.close();
                 req.close();


### PR DESCRIPTION
Как было:
При ошибке парсинга запроса клиент не получал никакого ответа, соединение просто закрывалось.

Как стало:
При ошибке парсинга запроса клиент получает ошибку в json с кодом HTTP 400.
При иных ошибках сервера клиент получает ошибку в json с кодом HTTP 500.

