### PR TITLE
Удаление невалидного кэша CRL файла

### DIFF
--- a/src/main/java/kz/ncanode/pki/CrlServiceProvider.java
+++ b/src/main/java/kz/ncanode/pki/CrlServiceProvider.java
@@ -148,6 +148,7 @@ public class CrlServiceProvider implements ServiceProvider {
             crl = (X509CRL) cf.generateCRL(fis);
             crlMemo.put(file.getName(), crl);
         } catch (CRLException | IOException | CertificateException e) {
+            file.delete();
             e.printStackTrace();
             return null;
         }

--- a/src/main/java/kz/ncanode/pki/PkiServiceProvider.java
+++ b/src/main/java/kz/ncanode/pki/PkiServiceProvider.java
@@ -330,6 +330,14 @@ public class PkiServiceProvider implements ServiceProvider {
                 result.add("NCA_MANAGER");
             } else if (item.equals("1.2.398.3.3.4.2.3")) {
                 result.add("NCA_OPERATOR");
+            } else if (item.equals("1.2.398.3.3.4.3")) {
+                result.add("IDENTIFICATION");
+            } else if (item.equals("1.2.398.3.3.4.3.1")) {
+                result.add("IDENTIFICATION_CON");
+            } else if (item.equals("1.2.398.3.3.4.3.2")) {
+                result.add("IDENTIFICATION_REMOTE");
+            } else if (item.equals("1.2.398.3.3.4.3.2.1")) {
+                result.add("IDENTIFICATION_REMOTE_DIGITAL_ID");
             }
         }
 


### PR DESCRIPTION
Иногда при скачивании CRL файлов с серверов pki, получаем невалидные файлы.
При дальнейшей попытке создать инстанс X509CRL, бросает исключение CRLException.
Невалидный кэш файл остается и при каждом вызове методов API NcaNode (cms sign, verify и т.д.) возвращает ошибку 500.

Если удалить невалидный кэш, при следующей попытке скачать CRL есть шанс получить нормальный файл.
