### PR TITLE
Исправления по Issue #159

### DIFF
--- a/src/main/java/kz/ncanode/service/CmsService.java
+++ b/src/main/java/kz/ncanode/service/CmsService.java
@@ -230,8 +230,14 @@ public class CmsService {
                     var attrs = signer.getUnsignedAttributes().toHashtable();
 
                     if (attrs.containsKey(PKCSObjectIdentifiers.id_aa_signatureTimeStampToken)) {
-                        Attribute attr = (Attribute) attrs.get(PKCSObjectIdentifiers.id_aa_signatureTimeStampToken);
-
+                        Attribute attr = null;
+                        Object obj = attrs.get(PKCSObjectIdentifiers.id_aa_signatureTimeStampToken);
+                        if(obj instanceof Vector) {
+                            attr = (Attribute)( ((Vector)obj).get(0) );
+                        }
+                        else {
+                            attr = (Attribute)obj;
+                        }
 
                         if (attr.getAttrValues().size() != 1) {
                             throw new Exception("Too many TSP tokens");


### PR DESCRIPTION
При множественном подписании атрибут с ID "PKCSObjectIdentifiers.id_aa_signatureTimeStampToken" не является экземпляром Attribute, а представляет собой Vector<Attribute>.

# Пулл реквест

Обход проблемы, описанной в Issue #159 