### PR TITLE
Обновление версий библиотек kalkan

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ https://profit.kz/news/56732/Otkritij-kod-Beeline-Hacktoberfest-v-Kazahstane/
 
 Документацию можно найти на http://ncanode.kz
 
+Swagger: https://v3.ncanode.kz/swagger-ui/
+
 ## Contributors
 
 <a href="https://github.com/malikzh/NCANode/graphs/contributors">
@@ -86,11 +88,14 @@ https://profit.kz/news/56732/Otkritij-kod-Beeline-Hacktoberfest-v-Kazahstane/
 
 ## Важно!!!
 
-По требованию  АО «НИТ» | НУЦ РК. Библиотеки `kalkancrypt-0.6.jar` и `kalkancrypt_xmldsig-0.3.jar`
+По требованию  АО «НИТ» | НУЦ РК. Библиотеки `kalkancrypt-*.jar`/`knca_provider_jce_kalkan-*.jar` и `kalkancrypt-xmldsig-*.jar`
 Были удалены из репозитория, поэтому для компиляции Вам необходимо подставить библиотеки
 из комплекта разработчика (SDK) в директорию `/lib`.
 
 ### Сборка проекта
+
+Версия gradle: 7.2
+Версия java: 17
 
 Для сборки проекта необходимо:
 
@@ -100,19 +105,30 @@ https://profit.kz/news/56732/Otkritij-kod-Beeline-Hacktoberfest-v-Kazahstane/
 
 Собранный проект будет лежать: `build/libs/NCANode.jar` или `build/libs/NCANode.war`
 
-### Запуск в Docker
-
-```bash
-docker volume create ncanode_cache
-docker run -p 14579:14579 -v ncanode_cache:/app/cache -d malikzh/ncanode
-```
-
 ### Запуск проекта без сборки
 
 Проект запустить можно командой:
 
 ```bash
 $ ./gradlew bootRun
+```
+
+### Запуск в Docker из готового образа
+
+```bash
+docker volume create ncanode_cache
+docker run -p 14579:14579 -v ncanode_cache:/app/cache -d malikzh/ncanode
+```
+
+### Запуск через Docker Compose
+
+Предварительно нужно собрать проект через gradle и сгенерировать jar файлы
+
+```bash
+docker compose build  // сборка образа
+docker compose up -d  // запуск контейнера
+docker compose ps  // проверка статуса контейнера
+docker compose stop  // остановка контейнера
 ```
 
 ### После запуска

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
     // KalkanCrypt
-    implementation name: 'kalkancrypt-0.7.2'
-    implementation name: 'kalkancrypt_xmldsig-0.4'
+    implementation name: 'knca_provider_jce_kalkan-0.7.5'
+    implementation name: 'kalkancrypt-xmldsig-0.5'
     implementation 'org.apache.santuario:xmlsec:2.1.7'
 
     // SOAP/WSSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services:
+  ncanode:
+    image: ncanode
+    restart: unless-stopped
+    build:
+      context: .
+    volumes:
+      - ncanode_cache:/app/cache
+    ports:
+      - "14579:14579"
+
+volumes:
+  ncanode_cache:

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,2 +1,3 @@
 kalkancrypt-*.jar
 kalkancrypt_xmldsig-*.jar
+knca_provider_jce_kalkan*.jar

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,5 +1,5 @@
 # README
 
-По требованию  АО «НИТ» | НУЦ РК. Библиотеки `kalkancrypt-0.7.jar` и `kalkancrypt_xmldsig-0.4.jar`
+По требованию  АО «НИТ» | НУЦ РК. Библиотеки `kalkancrypt-*.jar`/`knca_provider_jce_kalkan-*.jar` и `kalkancrypt-xmldsig-*.jar`
 Были удалены из репозитория, поэтому для компиляции Вам необходимо сюда подставить библиотеки
 из комплекта разработчика (SDK).


### PR DESCRIPTION
# Пулл реквест

В последней версии SDK изменились версии библиотек kalkan:
1. `kalkancrypt_xmldsig-0.4` -> `kalkancrypt-xmldsig-0.5`
2. `kalkancrypt-0.6.jar` -> `knca_provider_jce_kalkan-0.7.5`

Так же добавил описание в README.md и добавил docker compose для удобной сборки образа докер