### PR TITLE
bump xmlsec to 3.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     // KalkanCrypt
     implementation name: 'knca_provider_jce_kalkan-0.7.5'
     implementation name: 'kalkancrypt-xmldsig-0.5'
-    implementation 'org.apache.santuario:xmlsec:2.1.7'
+    implementation 'org.apache.santuario:xmlsec:3.0.3'
 
     // SOAP/WSSE
     implementation 'org.apache.ws.security:wss4j:1.6.19'


### PR DESCRIPTION
# Пулл реквест

Новая версии sdk требует xmlsec:3.0.3
Без него метод verify дает 500 ошибку