### PR TITLE
Корректная обработка email в CertificateWrapper

### DIFF
--- a/src/main/java/kz/ncanode/wrapper/CertificateWrapper.java
+++ b/src/main/java/kz/ncanode/wrapper/CertificateWrapper.java
@@ -259,7 +259,7 @@ public class CertificateWrapper {
                     subjectBuilder.locality((String)rdn.getValue());
                 } else if (rdn.getType().equalsIgnoreCase("S")) {
                     subjectBuilder.state((String)rdn.getValue());
-                } else if (rdn.getType().equalsIgnoreCase("E")) {
+                } else if ((rdn.getType().equalsIgnoreCase("E")) || (rdn.getType().equalsIgnoreCase("EMAILADDRESS"))) {
                     subjectBuilder.email((String)rdn.getValue());
                 } else if (rdn.getType().equalsIgnoreCase("O")) {
                     subjectBuilder.organization((String)rdn.getValue());
@@ -276,7 +276,7 @@ public class CertificateWrapper {
 
             return Optional.of(subjectBuilder.build());
         } catch (InvalidNameException e) {
-            log.warn("Distinguished name parseing error", e);
+            log.warn("Distinguished name parsing error", e);
             return Optional.empty();
         }
     }

--- a/src/test/groovy/kz/ncanode/unit/service/CertificateServiceTest.groovy
+++ b/src/test/groovy/kz/ncanode/unit/service/CertificateServiceTest.groovy
@@ -26,7 +26,7 @@ class CertificateServiceTest extends Specification implements WithTestData {
         result.signers.size() == 1
     }
 
-    def "invalid cetificate info method"() {
+    def "invalid certificate info method"() {
         given:
         def certs = [
             "YXNkYXNk"


### PR DESCRIPTION
Заметили что не всегда при проверке получаем email из сертификата. Небольшой анализ показал что кроме атрибута `E` нужно также проверять и атрибут `EMAILADDRESS`. 

Результат до (текущая версия NCANode):

```JSON
"subject": {
                "commonName": "ТЕСТОВ ТЕСТ",
                "surName": "ТЕСТ",
                "organization": "Товарищество с ограниченной ответственностью \"MITWORK\"",
                "iin": "000000000000",
                "bin": "150240008272",
                "country": "KZ",
                "dn": "EMAILADDRESS=test@mitwork.kz, GIVENNAME=ТЕСТОВИЧ, OU=BIN150240008272, O=\"Товарищество с ограниченной ответственностью \\\"MITWORK\\\"\", C=KZ, SERIALNUMBER=IIN000000000000, SURNAME=ТЕСТОВ, CN=ТЕСТОВ ТЕСТ"
            }
```

Результат после (с учетом доработки из текущего PR):

```JSON
"subject": {
                "commonName": "ТЕСТОВ ТЕСТ",
                "surName": "ТЕСТ",
                "email": "test@mitwork.kz",
                "organization": "Товарищество с ограниченной ответственностью \"MITWORK\"",
                "iin": "000000000000",
                "bin": "150240008272",
                "country": "KZ",
                "dn": "EMAILADDRESS=test@mitwork.kz, GIVENNAME=ТЕСТОВИЧ, OU=BIN150240008272, O=\"Товарищество с ограниченной ответственностью \\\"MITWORK\\\"\", C=KZ, SERIALNUMBER=IIN000000000000, SURNAME=ТЕСТОВ, CN=ТЕСТОВ ТЕСТ"
            }
```

P.S. Пример из метода `/pkcs12/info` с обработкой реального сертификата, персональные данные скрыты.