### PR TITLE
Поддержка работы документации swagger за реверсивным прокси

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,9 @@ ncanode:
   tsp:
     url: ${NCANODE_TSP_URL:http://tsp.pki.gov.kz/}
     retries: ${NCANODE_TSP_RETRIES:3}
+springdoc:
+  show-actuator: true
+  swagger-ui:
+    configUrl: ${SWAGGER_RELATIVE_PATH:}/v3/api-docs/swagger-config
+    oauth2RedirectUrl: ${SWAGGER_RELATIVE_PATH:}/swagger-ui/oauth2-redirect.html
+    url: ${SWAGGER_RELATIVE_PATH:}/v3/api-docs


### PR DESCRIPTION
# Пулл реквест
В случае, если сервис находится за реверсивным прокси,
например, внутренний адрес: http://ncanode.local:14579
а внешний: http://mysite.com/myncanode
то для корректной работы swagger-документации 
по адресу http://mysite.com/myncanode/swagger-ui/index.html 
нужно указать переменную окружения для докера  
SWAGGER_RELATIVE_PATH=/myncanode
