### PR TITLE
Реализация создания подписи методом SIGN_BYTES_ARRAY (аналогично eGov Mobile)

### DIFF
--- a/src/main/java/kz/ncanode/controller/X509Controller.java
+++ b/src/main/java/kz/ncanode/controller/X509Controller.java
@@ -3,6 +3,8 @@ package kz.ncanode.controller;
 import kz.ncanode.dto.certificate.CertificateRevocation;
 import kz.ncanode.dto.request.SbaVerifyRequest;
 import kz.ncanode.dto.request.X509InfoRequest;
+import kz.ncanode.dto.response.SbaSignResponse;
+import kz.ncanode.dto.request.SbaSignRequest;
 import kz.ncanode.dto.response.VerificationResponse;
 import kz.ncanode.service.CertificateService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RequiredArgsConstructor
 public class X509Controller {
     private final CertificateService certificateService;
+
+    @PostMapping("/sign")
+    public ResponseEntity<SbaSignResponse> sign(@Valid @RequestBody SbaSignRequest sbaSignRequest) {
+        return ResponseEntity.ok(certificateService.create(sbaSignRequest));
+    }
 
     @PostMapping("/info")
     public ResponseEntity<VerificationResponse> verify(@Valid @RequestBody X509InfoRequest x509InfoRequest) {

--- a/src/main/java/kz/ncanode/dto/request/SbaSignRequest.java
+++ b/src/main/java/kz/ncanode/dto/request/SbaSignRequest.java
@@ -1,0 +1,17 @@
+package kz.ncanode.dto.request;
+
+import kz.ncanode.dto.tsp.TsaPolicy;
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class SbaSignRequest {
+
+    @NotEmpty
+    private String data;
+
+    private SignerRequest signer;
+
+    private TsaPolicy tsaPolicy;
+}

--- a/src/main/java/kz/ncanode/dto/response/SbaSignResponse.java
+++ b/src/main/java/kz/ncanode/dto/response/SbaSignResponse.java
@@ -1,0 +1,16 @@
+package kz.ncanode.dto.response;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+@Jacksonized
+@EqualsAndHashCode(callSuper = true)
+@Data
+@SuperBuilder
+public class SbaSignResponse extends StatusResponse {
+    private String certificate;
+
+    private String signature;
+}

--- a/src/main/java/kz/ncanode/service/CertificateService.java
+++ b/src/main/java/kz/ncanode/service/CertificateService.java
@@ -5,6 +5,8 @@ import kz.ncanode.constants.MessageConstants;
 import kz.ncanode.dto.certificate.CertificateInfo;
 import kz.ncanode.dto.certificate.CertificateRevocation;
 import kz.ncanode.dto.request.Pkcs12InfoRequest;
+import kz.ncanode.dto.request.SbaSignRequest;
+import kz.ncanode.dto.response.SbaSignResponse;
 import kz.ncanode.dto.response.VerificationResponse;
 import kz.ncanode.exception.ServerException;
 import kz.ncanode.wrapper.CertificateWrapper;
@@ -177,6 +179,60 @@ public class CertificateService {
     public static X509Certificate load(byte[] cert) throws CertificateException, NoSuchProviderException, IOException {
         try (ByteArrayInputStream stream = new ByteArrayInputStream(cert)) {
             return (X509Certificate)java.security.cert.CertificateFactory.getInstance("X.509", KalkanProvider.PROVIDER_NAME).generateCertificate(stream);
+        }
+    }
+
+    public SbaSignResponse create(SbaSignRequest sbaSignRequest) {
+        try {
+            String keyBase64 = sbaSignRequest.getSigner().getKey();
+            //System.out.println("keyBase64: " + keyBase64);
+
+            byte[] keyBytes = Base64.getDecoder().decode(
+                keyBase64.replaceAll("\\s", ""));
+
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            try (ByteArrayInputStream is = new ByteArrayInputStream(keyBytes)) {
+                keyStore.load(is, sbaSignRequest.getSigner().getPassword().toCharArray());
+            }
+
+            String alias = sbaSignRequest.getSigner().getKeyAlias();
+
+            if (alias == null || alias.isBlank()) {
+                Enumeration<String> aliases = keyStore.aliases();
+
+                while (aliases.hasMoreElements()) {
+                    String current = aliases.nextElement();
+                    if (keyStore.isKeyEntry(current)) {
+                        alias = current;
+                        break;
+                    }
+                }
+            }
+
+            if (alias == null) {
+                throw new ServerException("Private key not found in PKCS12");
+            }
+
+            PrivateKey privateKey = (PrivateKey) keyStore.getKey(
+                alias,
+                sbaSignRequest.getSigner().getPassword().toCharArray());
+
+            X509Certificate certificate =
+                (X509Certificate) keyStore.getCertificate(alias);
+
+            Signature signature = Signature.getInstance(certificate.getSigAlgName());
+
+            signature.initSign(privateKey);
+            signature.update(sbaSignRequest.getData().getBytes(StandardCharsets.UTF_8));
+
+            byte[] signBytes = signature.sign();
+
+            return SbaSignResponse.builder()
+                .certificate(Base64.getEncoder().encodeToString(certificate.getEncoded()))
+                .signature(Base64.getEncoder().encodeToString(signBytes))
+                .build();
+        } catch (Exception e) {
+            throw new ServerException(e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
# Пулл реквест

Реализовано создание ЭЦП методом SIGN_BYTES_ARRAY (аналогично eGov Mobile). В ответе возвращаются:

signature — цифровая подпись переданных данных;
certificate — сертификат подписанта в формате Base64 (X.509), используемый для проверки подписи.

Корректность сформированных signature и certificate можно проверить с помощью метода /x509/verify.
